### PR TITLE
use bounds formatoption widget for colors dialog

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,5 +1,4 @@
 channels:
-- psyplot/label/bounds-dialog
 - psyplot/label/master
 - manics # Used by jupyter-desktop-server
 - conda-forge

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,4 +1,5 @@
 channels:
+- psyplot/label/bounds-dialog
 - psyplot/label/master
 - manics # Used by jupyter-desktop-server
 - conda-forge

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -299,6 +299,10 @@ class CmapDialog(QtWidgets.QDialog):
         vbox.addWidget(self.cbar_preview)
         vbox.addWidget(self.button_box)
 
+    @property
+    def plotter(self):
+        return self.bounds_widget.editor.fmto.plotter
+
     def update_preview(self):
         try:
             bounds = self.bounds_widget.editor.value

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -61,12 +61,12 @@ class BasemapDialog(QtWidgets.QDialog):
         self.opt_meri_every = QtWidgets.QRadioButton("Every:")
         self.txt_meri_every = QtWidgets.QLineEdit()
         self.txt_meri_every.setPlaceholderText("30 °E")
-        self.txt_meri_every.setValidator(QtGui.QDoubleValidator(-360, 360, 7))
+        self.txt_meri_every.setValidator(QtGui.QDoubleValidator(0, 360, 7))
 
         self.opt_meri_num = QtWidgets.QRadioButton("Number:")
         self.txt_meri_num = QtWidgets.QLineEdit()
         self.txt_meri_num.setPlaceholderText("5")
-        self.txt_meri_num.setValidator(QtGui.QIntValidator(1, 360))
+        self.txt_meri_num.setValidator(QtGui.QIntValidator(1, 720))
 
         form = QtWidgets.QFormLayout(self.meridionals_box)
         form.addRow(self.opt_meri_auto)
@@ -88,12 +88,12 @@ class BasemapDialog(QtWidgets.QDialog):
         self.opt_para_every = QtWidgets.QRadioButton("Every:")
         self.txt_para_every = QtWidgets.QLineEdit()
         self.txt_para_every.setPlaceholderText("30 °N")
-        self.txt_para_every.setValidator(QtGui.QDoubleValidator(-90, 90, 7))
+        self.txt_para_every.setValidator(QtGui.QDoubleValidator(0, 90, 7))
 
         self.opt_para_num = QtWidgets.QRadioButton("Number:")
         self.txt_para_num = QtWidgets.QLineEdit()
         self.txt_para_num.setPlaceholderText("5")
-        self.txt_para_num.setValidator(QtGui.QIntValidator(1, 180))
+        self.txt_para_num.setValidator(QtGui.QIntValidator(1, 360))
 
         form = QtWidgets.QFormLayout(self.parallels_box)
         form.addRow(self.opt_para_auto)

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -1,10 +1,6 @@
 """Dialogs for manipulating formatoptions."""
 import yaml
-import os.path as osp
-from psy_view.rcsetup import rcParams
-from psy_view import utils
-from functools import partial
-from PyQt5 import QtWidgets, QtGui, QtCore
+from PyQt5 import QtWidgets, QtGui
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas)
 from matplotlib.figure import Figure

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -492,6 +492,14 @@ class FormatoptionsEditor(QtWidgets.QWidget):
         return (self.text_edit.toPlainText() if self.multiline else
                 self.line_edit.text())
 
+    @text.setter
+    def text(self, s):
+        self.clear_text()
+        if self.multiline:
+            self.text_edit.insertPlainText(s)
+        else:
+            self.line_edit.insert(s)
+
     @property
     def value(self):
         text = self.text

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -2,6 +2,9 @@
 import yaml
 
 from PyQt5 import QtWidgets, QtGui
+from matplotlib.backends.backend_qt5agg import (
+    FigureCanvasQTAgg as FigureCanvas)
+from matplotlib.figure import Figure
 
 
 class BasemapDialog(QtWidgets.QDialog):
@@ -249,174 +252,156 @@ class BasemapDialog(QtWidgets.QDialog):
 class CmapDialog(QtWidgets.QDialog):
     """A dialog to modify color bounds"""
 
-    def __init__(self, plotter, *args, **kwargs):
+    def __init__(self, project, *args, **kwargs):
+        from psy_simple.widgets.colors import BoundsFmtWidget
         super().__init__(*args, **kwargs)
         self.button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
             self)
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
+
+        self.fmt_widgets = {}
+
         self.tabs = QtWidgets.QTabWidget()
-        self.bounds_widget = BoundaryWidget(
-            plotter.cmap.value, plotter.bounds.value)
+        plotter = project(fmts=['cmap', 'bounds']).plotters[0]
+        self.bounds_widget = self.fmt_widgets['bounds'] = LabelWidgetLine(
+            plotter.bounds, project, BoundsFmtWidget,
+            widget_kws=dict(properties=False))
+        self.bounds_widget.editor.line_edit.textChanged.connect(
+            self.update_preview_from_bounds)
         self.tabs.addTab(self.bounds_widget, "Colormap boundaries")
+
+        self.cbar_preview = ColorbarPreview(plotter)
+        self.cbar_preview.setMaximumHeight(self.tabs.sizeHint().height() // 3)
 
         vbox = QtWidgets.QVBoxLayout(self)
         vbox.addWidget(self.tabs)
+        vbox.addWidget(self.cbar_preview)
         vbox.addWidget(self.button_box)
 
+    def update_preview_from_bounds(self):
+        try:
+            bounds = self.bounds_widget.editor.value
+        except Exception:
+            return
+        if bounds is not None:
+            self.cbar_preview.update_colorbar(bounds=bounds)
+
+    @property
+    def fmts(self):
+        ret = {}
+        for fmt, widget in self.fmt_widgets.items():
+            if widget.editor.changed:
+                try:
+                    value = widget.editor.value
+                except:
+                    raise IOError(f"{fmt}-value {widget.editor.text} could "
+                                  "not be parsed to python!")
+                else:
+                    ret[fmt] = value
+        return ret
+
     @classmethod
-    def update_plotter(cls, plotter):
-        dialog = cls(plotter)
+    def update_project(cls, project, *fmts):
+        dialog = cls(project, *fmts)
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()
         dialog.exec_()
         if dialog.result() == QtWidgets.QDialog.Accepted:
-            plotter.update(
-                **dialog.bounds_widget.value)
+            project.update(
+                **dialog.fmts)
 
 
-class BoundaryWidget(QtWidgets.QWidget):
-    """A widget to select colormap boundaries"""
+class ColorbarPreview(FigureCanvas):
+    """Ultimately, this is a QWidget (as well as a FigureCanvasAgg, etc.)."""
 
-    def __init__(self, cmap_value, init_value, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, plotter, parent=None, *args, **kwargs):
+        fig = Figure(*args, **kwargs)
 
-        layout = QtWidgets.QGridLayout(self)
+        FigureCanvas.__init__(self, fig)
+        self.setParent(parent)
 
-        self.type_box = QtWidgets.QGroupBox()
-        vbox = QtWidgets.QVBoxLayout(self.type_box)
-        self.opt_rounded = QtWidgets.QRadioButton("Rounded")
-        self.opt_minmax = QtWidgets.QRadioButton("Exact")
-        self.opt_custom = QtWidgets.QRadioButton("Custom")
-        vbox.addWidget(self.opt_rounded)
-        vbox.addWidget(self.opt_minmax)
-        vbox.addWidget(self.opt_custom)
+        FigureCanvas.setSizePolicy(self,
+                                   QtWidgets.QSizePolicy.Expanding,
+                                   QtWidgets.QSizePolicy.Expanding)
+        FigureCanvas.updateGeometry(self)
+        self.axes_counter = 0
 
-        layout.addWidget(self.type_box, 0, 0, 3, 1)
+        self.plotter = plotter
+        self.init_colorbar(plotter)
 
-        self.min_box = QtWidgets.QGroupBox()
-        hbox = QtWidgets.QHBoxLayout(self.min_box)
-        self.opt_min = QtWidgets.QRadioButton("Minimum")
-        self.opt_min_pctl = QtWidgets.QRadioButton("Percentile")
-        self.txt_min_pctl = QtWidgets.QLineEdit()
-        self.txt_min_pctl.setValidator(QtGui.QDoubleValidator(0., 100., 5))
-        hbox.addWidget(self.opt_min)
-        hbox.addWidget(self.opt_min_pctl)
-        hbox.addWidget(self.txt_min_pctl)
+    def resizeEvent(self, event):
+        h = event.size().height()
+        if h <= 0:
+            return
+        return super().resizeEvent(event)
 
-        layout.addWidget(self.min_box, 0, 1, 1, 2)
+    def init_colorbar(self, plotter):
+        from matplotlib.cm import ScalarMappable
+        norm = plotter.bounds.norm
+        cmap = plotter.cmap.get_cmap(self.plotter.plot.array)
 
-        self.max_box = QtWidgets.QGroupBox()
-        hbox = QtWidgets.QHBoxLayout(self.max_box)
-        self.opt_max = QtWidgets.QRadioButton("Maximum")
-        self.opt_max_pctl = QtWidgets.QRadioButton("Percentile")
-        self.txt_max_pctl = QtWidgets.QLineEdit()
-        self.txt_max_pctl.setValidator(QtGui.QDoubleValidator(0., 100., 5))
-        hbox.addWidget(self.opt_max)
-        hbox.addWidget(self.opt_max_pctl)
-        hbox.addWidget(self.txt_max_pctl)
+        self.mappable = sm = ScalarMappable(cmap=cmap, norm=norm)
+        sm.set_array([])
 
-        layout.addWidget(self.max_box, 1, 1, 1, 2)
+        self.cax = self.figure.add_axes([0.1, 0.5, 0.8, 0.5],
+                                        label=self.axes_counter)
 
-        self.txt_custom = QtWidgets.QLineEdit()
-        self.txt_custom.setPlaceholderText('1, 2, 3, 4, 5, ...')
-        # TODO: Add validator
-        layout.addWidget(self.txt_custom, 2, 1, 1, 2)
-
-        self.cb_symmetric = QtWidgets.QCheckBox("symmetric")
-        layout.addWidget(self.cb_symmetric, 3, 0)
-
-        self.cb_inverted = QtWidgets.QCheckBox("inverted")
-        layout.addWidget(self.cb_inverted, 3, 1)
-        self.cb_inverted.setChecked(cmap_value.endswith('_r'))
-        self.init_cmap = cmap_value
-
-        self.txt_levels = QtWidgets.QLineEdit()
-        self.txt_levels.setInputMask(r"\B\o\u\n\d\s\: 900")
-        self.txt_levels.setMaxLength(len('Bounds: 256'))
-        layout.addWidget(self.txt_levels)
-
-        self.fill_form(init_value)
-
-        for button in [self.opt_minmax, self.opt_rounded, self.opt_custom,
-                       self.opt_min, self.opt_max,
-                       self.opt_min_pctl, self.opt_max_pctl]:
-            button.clicked.connect(self.update_type)
-
-    def update_type(self):
-        custom = self.opt_custom.isChecked()
-        self.txt_custom.setEnabled(custom)
-        self.opt_min.setEnabled(not custom)
-        self.opt_max.setEnabled(not custom)
-        self.opt_min_pctl.setEnabled(not custom)
-        self.opt_max_pctl.setEnabled(not custom)
-        self.txt_min_pctl.setEnabled(self.opt_min_pctl.isChecked())
-        self.txt_max_pctl.setEnabled(self.opt_max_pctl.isChecked())
+        self.cbar = self.figure.colorbar(
+            sm, norm=norm, cmap=cmap, cax=self.cax, orientation='horizontal')
 
     @property
-    def value(self):
-        cmap = self.init_cmap
-        if self.cb_inverted.isChecked() and not cmap.endswith('_r'):
-            cmap = cmap + '_r'
-        elif not self.cb_inverted.isChecked() and cmap.endswith('_r'):
-            cmap = cmap[:-2]
-        if self.opt_custom.isChecked():
-            bounds = list(map(float, self.txt_custom.text().split(',')))
-            if not bounds:
-                bounds = ['rounded', None]
-        else:
-            if self.opt_minmax.isChecked():
-                val = 'minmax' if not self.cb_symmetric.isChecked() else 'sym'
-            else:
-                val = ('rounded' if not self.cb_symmetric.isChecked() else
-                       'roundedsym')
-            bounds = [val]
-            levels = self.txt_levels.text()[len('Bounds: '):]
-            bounds.append(int(levels) if levels.strip() else None)
-            bounds.append(0 if self.opt_min.isChecked() else
-                          float(self.txt_min_pctl.text().strip() or 0))
-            bounds.append(100 if self.opt_max.isChecked() else
-                          float(self.txt_max_pctl.text().strip() or 100))
+    def fake_plotter(self):
+        from psyplot.plotter import Plotter
 
-        return {'bounds': bounds, 'cmap': cmap}
+        class FakePlotter(Plotter):
+            bounds = self.plotter.bounds.__class__('bounds')
+            cmap = self.plotter.cmap.__class__('cmap')
 
+            _rcparams_string = self.plotter._get_rc_strings()
 
+        ref = self.plotter
 
-    def fill_form(self, value):
+        plotter = FakePlotter(
+            ref.data.copy(), make_plot=False, bounds=ref['bounds'],
+            cmap=ref['cmap'])
+        plotter.plot_data = ref.plot_data
+        return plotter
 
-        if value[0] == 'rounded' or value[0] == 'roundedsym':
-            self.opt_rounded.setChecked(True)
-        elif value[0] == 'minmax' or value[0] == 'sym':
-            self.opt_minmax.setChecked(True)
-        else:
-            self.opt_custom.setChecked(True)
-            self.txt_custom.setText(', '.join(map(str, value)))
-            self.txt_levels.setText('Bounds: %i' % len(value))
+    def update_colorbar(self, **kwargs):
+        plotter = self.fake_plotter
+
+        try:
+            for key, val in kwargs.items():
+                plotter[key] = val
+        except (ValueError, TypeError):
             return
-        self.txt_levels.setText('Bounds: %s' % (value[1] or ''))
-        self.txt_custom.setEnabled(False)
 
-        min_pctl = 0 if len(value) <= 2 else value[2]
-        if min_pctl == 0:
-            self.opt_min.setChecked(True)
-            self.txt_min_pctl.setText('0')
-            self.txt_min_pctl.setEnabled(False)
-        else:
-            self.opt_min_pctl.setChecked(True)
-            self.txt_min_pctl.setText(str(min_pctl))
+        plotter.initialize_plot()
 
-        max_pctl = 100 if len(value) <= 3 else value[3]
-        if max_pctl == 100:
-            self.opt_max.setChecked(True)
-            self.txt_max_pctl.setText('100')
-            self.txt_max_pctl.setEnabled(False)
-        else:
-            self.opt_max_pctl.setChecked(True)
-            self.txt_max_pctl.setText(str(max_pctl))
+        current_norm = self.mappable.norm
+        current_cmap = self.mappable.get_cmap()
 
-        self.cb_symmetric.setChecked(value[0].endswith('sym'))
+
+        try:
+            try:
+                plotter.bounds.norm._check_vmin_vmax()
+            except (AttributeError, TypeError):
+                pass
+            try:
+                plotter.bounds.norm.autoscale_None(plotter.bounds.array)
+            except AttributeError:
+                pass
+            self.mappable.set_norm(plotter.bounds.norm)
+            self.mappable.set_cmap(plotter.cmap.get_cmap(
+                self.plotter.plot.array))
+            self.draw()
+
+        except Exception:
+            self.mappable.set_norm(current_norm)
+            self.mappable.set_cmap(current_cmap)
 
 
 class FormatoptionsEditor(QtWidgets.QWidget):
@@ -425,6 +410,8 @@ class FormatoptionsEditor(QtWidgets.QWidget):
     def __init__(self, fmto, *args, **kwargs):
         super().__init__(*args, **kwargs)
         layout = QtWidgets.QHBoxLayout()
+
+        self.fmto = fmto
 
         self.line_edit = QtWidgets.QLineEdit()
         layout.addWidget(self.line_edit)
@@ -475,6 +462,10 @@ class FormatoptionsEditor(QtWidgets.QWidget):
         else:
             self.line_edit.clear()
 
+    def set_obj(self, obj):
+        self.clear_text()
+        self.insert_obj(obj)
+
     def insert_obj(self, obj):
         """Add a string to the formatoption widget"""
         current = self.text
@@ -512,20 +503,22 @@ class FormatoptionsEditor(QtWidgets.QWidget):
 class LabelWidgetLine(QtWidgets.QGroupBox):
     """A widget to change the labels"""
 
-    def __init__(self, fmto, project, *args, **kwargs):
-        from psy_simple.widgets.texts import LabelWidget
+    def __init__(self, fmto, project, fmto_widget,
+                 widget_kws={}, *args, **kwargs):
         super().__init__(f'{fmto.name} ({fmto.key})', *args, **kwargs)
         self.editor = FormatoptionsEditor(fmto)
         vbox = QtWidgets.QVBoxLayout()
-        vbox.addWidget(LabelWidget(self.editor, fmto, project,
-                                   properties=False))
+        vbox.addWidget(
+            fmto_widget(self.editor, fmto, project, **widget_kws))
         vbox.addWidget(self.editor)
         self.setLayout(vbox)
+
 
 class LabelDialog(QtWidgets.QDialog):
     """A widget to change labels"""
 
     def __init__(self, project, *fmts):
+        from psy_simple.widgets.texts import LabelWidget
         super().__init__()
         self.project = project
         layout = QtWidgets.QVBoxLayout()
@@ -533,7 +526,8 @@ class LabelDialog(QtWidgets.QDialog):
         self.fmt_widgets = {}
         for fmt in fmts:
             fmto = getattr(plotter, fmt)
-            fmt_widget = LabelWidgetLine(fmto, project)
+            fmt_widget = LabelWidgetLine(
+                fmto, project, LabelWidget, widget_kws=dict(properties=False))
             self.fmt_widgets[fmt] = fmt_widget
             layout.addWidget(fmt_widget)
 

--- a/psy_view/dialogs.py
+++ b/psy_view/dialogs.py
@@ -330,15 +330,14 @@ class CmapDialog(QtWidgets.QDialog):
         return ret
 
     @classmethod
-    def update_project(cls, project, *fmts):
-        dialog = cls(project, *fmts)
+    def update_project(cls, project):
+        dialog = cls(project)
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()
         dialog.exec_()
         if dialog.result() == QtWidgets.QDialog.Accepted:
-            project.update(
-                **dialog.fmts)
+            project.update(**dialog.fmts)
 
 
 class ColorbarPreview(FigureCanvas):
@@ -471,8 +470,9 @@ class FormatoptionsEditor(QtWidgets.QWidget):
         self.initial_value = self.line_edit.text()
         self.setLayout(layout)
 
+    @property
     def changed(self):
-        return self.text != self.initial_value
+        return self.fmto.diff(self.fmto.validate(self.get_obj()))
 
     def toggle_multiline(self):
         multiline = self.multiline

--- a/psy_view/plotmethods.py
+++ b/psy_view/plotmethods.py
@@ -337,6 +337,10 @@ class MapPlotWidget(PlotMethodWidget):
 
     def edit_color_settings(self):
         dialogs.CmapDialog.update_project(self.sp)
+        if isinstance(self.plotter.cmap.value, str):
+            self.btn_cmap.setText(self.plotter.cmap.value)
+        else:
+            self.btn_cmap.setText('Custom')
 
     def choose_next_projection(self):
         select = False

--- a/psy_view/plotmethods.py
+++ b/psy_view/plotmethods.py
@@ -324,7 +324,7 @@ class MapPlotWidget(PlotMethodWidget):
             self.sp, 'figtitle', 'title', 'clabel')
 
     def edit_color_settings(self):
-        dialogs.CmapDialog.update_plotter(self.plotter)
+        dialogs.CmapDialog.update_project(self.sp)
 
     def choose_next_projection(self):
         select = False

--- a/psy_view/rcsetup.py
+++ b/psy_view/rcsetup.py
@@ -5,12 +5,6 @@ from psyplot.config.rcsetup import validate_dict
 
 
 defaultParams = {
-    "cmaps": [["viridis", "Reds", "Blues", "Greens", "binary",
-               "RdBu", "coolwarm", "red_white_blue", "winter",
-               "jet", "white_blue_red", "gist_ncar",
-               "gist_earth", "Paired", "gnuplot", "gnuplot2"],
-              validate_stringlist,
-              "The names of available colormaps"],
     "projections": [
         ["cf", "cyl", "robin", "ortho", "moll"], validate_stringlist,
         "The names of available projections"],

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,0 +1,80 @@
+"""Test the formatoption dialogs"""
+import pytest
+
+
+@pytest.fixture
+def test_project(test_ds):
+    sp = test_ds.psy.plot.mapplot(name='t2m')
+    yield sp
+    sp.close()
+
+
+@pytest.fixture
+def cmap_dialog(qtbot, test_project):
+    from psy_view.dialogs import CmapDialog
+    dialog = CmapDialog(test_project)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+def test_colorbar_preview_valid_bounds(cmap_dialog):
+    """Test whether the update to a new bounds setting works"""
+    bounds = [240, 270, 310]
+    cmap_dialog.bounds_widget.editor.set_obj(bounds)
+
+    assert list(cmap_dialog.cbar_preview.cbar.norm.boundaries) == bounds
+
+
+def test_colorbar_preview_valid_cmap(cmap_dialog):
+    """Test whether the update to a new cmap setting works"""
+    cmap = 'Blues'
+    cmap_dialog.cmap_widget.editor.set_obj(cmap)
+
+    assert cmap_dialog.cbar_preview.cbar.cmap.name == cmap
+
+
+def test_colorbar_preview_valid_ticks(cmap_dialog):
+    """Test whether the update to a new cticks setting works"""
+    ticks = [285, 290]
+    cmap_dialog.cticks_widget.editor.set_obj(ticks)
+
+    assert list(cmap_dialog.cbar_preview.cbar.get_ticks()) == ticks
+
+
+def test_colorbar_preview_invalid_bounds(cmap_dialog):
+    """Test whether the update to a invalid bounds setting works"""
+    bounds = list(cmap_dialog.cbar_preview.cbar.norm.boundaries)
+
+    # set invalid bounds
+    cmap_dialog.bounds_widget.editor.text = '[1, 2, 3'
+
+    assert list(cmap_dialog.cbar_preview.cbar.norm.boundaries) == bounds
+
+
+def test_colorbar_preview_invalid_cmap(cmap_dialog):
+    """Test whether the update to a invalued cmap setting works"""
+    cmap = cmap_dialog.cbar_preview.cbar.cmap.name
+
+    # set invalid cmap
+    cmap_dialog.cmap_widget.editor.text = 'Blue'
+
+    assert cmap_dialog.cbar_preview.cbar.cmap.name == cmap
+
+
+def test_colorbar_preview_invalid_ticks(cmap_dialog):
+    """Test whether the update to a new color setting works"""
+    ticks = list(cmap_dialog.cbar_preview.cbar.get_ticks())
+
+    # set invalid ticks
+    cmap_dialog.cticks_widget.editor.text = '[1, 2, 3'
+
+    assert list(cmap_dialog.cbar_preview.cbar.get_ticks()) == ticks
+
+
+def test_cmap_dialog_fmts(cmap_dialog):
+    """Test the updating of formatoptions"""
+    assert not cmap_dialog.fmts
+
+    cmap_dialog.bounds_widget.editor.set_obj('minmax')
+
+    assert cmap_dialog.fmts == {'bounds': 'minmax'}

--- a/tests/test_ds_widget.py
+++ b/tests/test_ds_widget.py
@@ -148,7 +148,7 @@ def test_cmap(qtbot, ds_widget, plotmethod):
     qtbot.mouseClick(ds_widget.variable_buttons['t2m'], Qt.LeftButton)
     cmap = ds_widget.plotter.cmap.value
     assert ds_widget.plotter.plot.mappable.get_cmap().name == cmap
-    qtbot.mouseClick(ds_widget.plotmethod_widget.btn_cmap, Qt.LeftButton)
+    ds_widget.plotmethod_widget.btn_cmap.menu().actions()[5].trigger()
     assert ds_widget.plotter.cmap.value != cmap
     assert ds_widget.plotter.plot.mappable.get_cmap().name != cmap
     qtbot.mouseClick(ds_widget.variable_buttons['t2m'], Qt.LeftButton)


### PR DESCRIPTION
This commit revises the color settings dialog and uses the bounds formatoption dialog. We additionally added a live-updating preview of the resulting colorbar

@tobstac: It would be nice of you could have a look at it on mybinder and give me some feedback :smiley: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/psyplot/psy-view/bounds-dialog?urlpath=%2Fdesktop) I also added a discrete logarithmic option

This PR integrates with https://github.com/psyplot/psy-simple/pull/14

- [x] implemented better selection of colormaps
- [x] Tests added (for all bug fixes or enhancements)
- [x] Tests passed (for all non-documentation changes)
- [x] revert 8ffe4c9e763ce85298927b4e39f261972330160b
 
Closes #7