### PR TITLE
Presets

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -44,3 +44,32 @@ application/x-netcdf=Psy-View.Desktop
 [Added Associations]
 application/x-netcdf=Psy-View.desktop;application/x-netcdf=Psyplot.desktop;
 EOF
+
+# create a demo preset
+mkdir -p $HOME/.config/psyplot/presets
+cat > $HOME/.config/psyplot/presets/EUR-temperature.yml << EOF
+clabel: '%(long_name)s %(units)s'
+cmap: YlOrRd
+datagrid: k-
+lonlatbox: Europe
+lsm:
+  coast:
+  - 0.0
+  - 0.0
+  - 0.0
+  - 1.0
+  land:
+  - 0.6666666666666666
+  - 0.3333333333333333
+  - 0.0
+  - 1.0
+  ocean:
+  - 0.592156862745098
+  - 0.7137254901960784
+  - 0.8823529411764706
+  - 1.0
+  res: 50m
+title: '%(long_name)s over Europe'
+xgrid: false
+ygrid: false
+EOF

--- a/psy_view/ds_widget.py
+++ b/psy_view/ds_widget.py
@@ -172,6 +172,7 @@ class DatasetWidget(QtWidgets.QSplitter):
         self.btn_unset_preset = utils.add_pushbutton(
             get_psy_icon('invalid.png'), self.unset_preset,
             "Unset the current preset", hbox, icon=True)
+        self.btn_unset_preset.setVisible(False)
 
         self.export_box.addWidget(self.frm_preset)
 

--- a/psy_view/ds_widget.py
+++ b/psy_view/ds_widget.py
@@ -703,11 +703,6 @@ class DatasetWidget(QtWidgets.QSplitter):
                     with self.block_widgets(self.combo_array):
                         current = self.combo_array.currentIndex()
                         self.combo_array.setCurrentIndex(current - 1)
-                else:
-                    self.btn_del.setEnabled(False)
-                    self.btn_export.setEnabled(False)
-                    for action in self._save_preset_actions:
-                        action.setEnabled(False)
 
             else:
                 with self.silence_variable_buttons():
@@ -715,8 +710,6 @@ class DatasetWidget(QtWidgets.QSplitter):
                         if var != v:
                             btn.setChecked(False)
                 self.make_plot()
-                self.btn_del.setEnabled(True)
-                self.btn_export.setEnabled(True)
             self.refresh()
 
         return func
@@ -1067,10 +1060,15 @@ class DatasetWidget(QtWidgets.QSplitter):
             variable = self.data.name
             for action in self._save_preset_actions:
                 action.setEnabled(True)
+            self.btn_del.setEnabled(True)
+            self.btn_export.setEnabled(True)
         else:
             variable = self.variable
             for action in self._save_preset_actions:
                 action.setEnabled(False)
+            self.btn_del.setEnabled(False)
+            self.btn_export.setEnabled(False)
+
 
         # refresh variable buttons
         with self.silence_variable_buttons():

--- a/psy_view/ds_widget.py
+++ b/psy_view/ds_widget.py
@@ -81,7 +81,7 @@ class DatasetWidget(QtWidgets.QSplitter):
         self.lbl_ds = QtWidgets.QLineEdit()
         self.open_box.addWidget(self.lbl_ds)
         self.btn_open = utils.add_pushbutton(
-            get_psy_icon('invalid.png'), lambda: self.set_dataset(),
+            get_psy_icon('run_arrow.png'), lambda: self.set_dataset(),
             "Select and open a netCDF dataset", self.open_box, icon=True)
         self.open_widget = QtWidgets.QWidget()
         self.open_widget.setLayout(self.open_box)

--- a/psy_view/ds_widget.py
+++ b/psy_view/ds_widget.py
@@ -554,6 +554,7 @@ class DatasetWidget(QtWidgets.QSplitter):
         self._preset = preset
         if self.sp:
             self.sp.load_preset(preset)
+            self.refresh()
         self.maybe_show_preset()
 
     def unset_preset(self):


### PR DESCRIPTION
closes #3 

This PR builds upon psyplot/psyplot#24 and psyplot/psyplot-gui#17 and implements the preset functionality into psy-view. We add a tool-button with a menu to save and load the current plot settings as a preset
![image](https://user-images.githubusercontent.com/9960249/86060365-dcac5980-ba64-11ea-810a-eb89fc6e4c73.png)  

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
