### PR TITLE
Gridlayout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,12 @@
+v0.0.2.b0
+=========
+
+Changed
+-------
+- The plotmethod tabs have now a more intuitive gridlayout (see
+  `#46 <https://github.com/psyplot/psy-view/pull/46>`__)
+
+Added
+-----
+- A widget to control the plot type for mapplot and plot2d (see
+  `#46 <https://github.com/psyplot/psy-view/pull/46>`__)

--- a/psy_view/plotmethods.py
+++ b/psy_view/plotmethods.py
@@ -829,6 +829,12 @@ class MapPlotWidget(PlotMethodWidget):
         if 'units' in var.attrs:
             fmts['clabel'] += ' %(units)s'
 
+        fmts['plot'] = self.plot_types[self.combo_plot.currentIndex()]
+        if fmts['plot'] == 'contour':
+            # we need to set a global map extend, see
+            # https://github.com/SciTools/cartopy/issues/1673
+            fmts['map_extent'] = 'global'
+
         if init:
             fmts.update(self.init_dims(var))
 

--- a/psy_view/rcsetup.py
+++ b/psy_view/rcsetup.py
@@ -32,8 +32,8 @@ from psyplot.config.rcsetup import validate_dict
 
 defaultParams: Dict[str, List[Any]] = {
     "projections": [
-        ["cf", "cyl", "robin", "ortho", "moll"], validate_stringlist,
-        "The names of available projections"],
+        ["cf", "cyl", "robin", "ortho", "moll", "northpole", "southpole"],
+         validate_stringlist, "The names of available projections"],
     "savefig_kws": [
         dict(dpi=250), validate_dict,
         "Options that are passed to plt.savefig when exporting images"],

--- a/tests/test_ds_widget.py
+++ b/tests/test_ds_widget.py
@@ -20,6 +20,21 @@ def test_mapplot(qtbot, ds_widget):
     qtbot.mouseClick(ds_widget.variable_buttons['t2m'], Qt.LeftButton)
     assert not ds_widget.sp
 
+
+@pytest.mark.parametrize('plotmethod', ['mapplot', 'plot2d'])
+@pytest.mark.parametrize('i', list(range(5)))
+def test_change_plot_type(qtbot, ds_widget, plotmethod, i):
+    """Test plotting and closing with mapplot"""
+    ds_widget.plotmethod = plotmethod
+    qtbot.mouseClick(ds_widget.variable_buttons['t2m'], Qt.LeftButton)
+    assert ds_widget.sp
+    pm_widget = ds_widget.plotmethod_widget
+    pm_widget.combo_plot.setCurrentIndex(i)
+    plot_type = pm_widget.plot_types[i]
+
+    assert ds_widget.sp.plotters[0].plot.value == plot_type
+
+
 @pytest.mark.parametrize('plotmethod', ['mapplot', 'plot2d'])
 def test_variable_switch(qtbot, ds_widget, plotmethod):
     """Test switching of variables"""
@@ -332,9 +347,6 @@ def test_open_and_close_plots(
     assert not bool(ds_widget._sp)
     assert not any(btn.isChecked() for name, btn in
                    ds_widget.variable_buttons.items())
-
-
-
 
 
 @pytest.mark.parametrize('plotmethod', ['mapplot', 'plot2d', 'lineplot'])


### PR DESCRIPTION
With this commit, we introduce a more general way of positioning the widgets in the plotmethod tabs that control the formatoptions. The layout of plotmethod tabs is now based on a qgridlayout with a standard interface that manages the various rows.

Furthermore, we add a combo box to select the plot type for mapplot and plot2d and changed the name for projections in the GUI to something more explanatory.

![image](https://user-images.githubusercontent.com/9960249/97772114-222c8080-1b44-11eb-99b0-e8cf32dfd200.png)

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
