### PR TITLE
Close the QApplication when closing the app widget

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changed
 -------
 - The plotmethod tabs have now a more intuitive gridlayout (see
   `#46 <https://github.com/psyplot/psy-view/pull/46>`__)
+- When closing the mainwindow of psy-view now, one closes all open windows (i.e.
+  also the open figures, see
+  `#47 <https://github.com/psyplot/psy-view/pull/47>`__)
 
 Added
 -----

--- a/psy_view/__init__.py
+++ b/psy_view/__init__.py
@@ -78,11 +78,11 @@ def start_app(
 
     rcParams['help_explorer.use_webengineview'] = False
 
-    from psy_view.ds_widget import DatasetWidget
+    from psy_view.ds_widget import DatasetWidgetStandAlone
     from psyplot_gui.common import get_icon
 
     app = QtWidgets.QApplication(sys.argv)
-    ds_widget = DatasetWidget(ds)
+    ds_widget = DatasetWidgetStandAlone(ds)
     ds_widget.setWindowIcon(QIcon(get_icon('logo.svg')))
     if preset is not None:
         ds_widget.load_preset(preset)


### PR DESCRIPTION
This PR adds a new subclass of the DatasetWidget that lets the QApplication quit when the window is closed.

This subclass is now used for starting the app via command line

 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
