### PR TITLE
Add a reload button

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,3 +13,6 @@ Added
 -----
 - A widget to control the plot type for mapplot and plot2d (see
   `#46 <https://github.com/psyplot/psy-view/pull/46>`__)
+- A button to reload all plots. This is useful, for instance, if the data on
+  your disk changed and you just want to update the plot
+  `#48 <https://github.com/psyplot/psy-view/pull/48>`__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,17 @@ import pytest
 import psyplot_gui.compat.qtcompat
 
 
-test_dir = osp.dirname(__file__)
+_test_dir = osp.dirname(__file__)
 
 
+@pytest.fixture
+def test_dir() -> str:
+    return _test_dir
 
 
 @pytest.fixture(params=["regular-test.nc", "regional-icon-test.nc",
                         "rotated-pole-test.nc", "icon-test.nc"])
-def test_file(request):
+def test_file(test_dir, request):
     return osp.join(test_dir, request.param)
 
 


### PR DESCRIPTION
This PR adds a button to close the current project and regenerate all figures. This will also close the handles to the datasets on disk, so it is useful when your data on the disk changed, but you do not want to click on everything to make new plots.


 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
